### PR TITLE
Fix OCR worker initialization hang

### DIFF
--- a/scripts/ocr.js
+++ b/scripts/ocr.js
@@ -48,6 +48,8 @@ export async function ensureWorker(reportStatus) {
         },
       });
 
+      sendStatus(reportStatus, { status: 'loading', message: 'Loading OCR engine', progress: 0.4 });
+      await worker.load();
       sendStatus(reportStatus, { status: 'loading', message: 'Loading English language', progress: 0.6 });
       await worker.loadLanguage('eng');
       sendStatus(reportStatus, { status: 'loading', message: 'Initializing OCR', progress: 0.8 });


### PR DESCRIPTION
## Summary
- ensure the Tesseract worker loads its core before loading language data
- surface a status update for the OCR engine load step so progress keeps moving

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9cb3bb9b08322aa39779ccb9f7216