### PR TITLE
Load Tesseract from CDN mirrors instead of bundled binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ loaded via WebAssembly, all computation stays on-device, and encounter history i
 - 🎥 **Live camera scanning** – request the rear camera, capture frames every few seconds, and highlight detected plates.
 - 🖼 **Still image processing** – upload a photo when camera permissions are unavailable.
 - 📊 **Local stats** – encounters are aggregated in `localStorage`, can be exported as CSV, and cleared at any time.
-- 🌐 **Static hosting** – the project ships as plain HTML/CSS/JS with CDN-hosted dependencies so it works on GitHub Pages without
-  installing Node packages.
+- 🌐 **Static hosting** – the project ships as plain HTML/CSS/JS and loads Tesseract.js from multiple CDNs at runtime so it works on
+  GitHub Pages without installing Node packages.
 
 ## Getting Started
 
@@ -61,7 +61,7 @@ DEV_PLAN.md         # Development notes from the original project
 
 ## How it works
 
-- `scripts/ocr.js` loads Tesseract.js from a CDN and keeps a single worker alive to process frames.
+- `scripts/ocr.js` dynamically loads the Tesseract.js library from multiple CDN mirrors and keeps a single worker alive to process frames.
 - `scripts/camera.js` captures frames from `getUserMedia`, throttles recognition, and forwards detections.
 - `scripts/store.js` tracks encounter history in `localStorage` and exposes helpers for exporting or clearing data.
 - `scripts/main.js` wires the UI, camera controller, store updates, and still image uploads together.
@@ -69,7 +69,7 @@ DEV_PLAN.md         # Development notes from the original project
 ## Browser Support
 
 - Modern Chromium, Firefox, and Safari browsers that support ES modules and `getUserMedia` (iOS 15+).
-- Because the OCR model is fetched from a CDN, the first load may take a few seconds depending on network speed.
+- Because the OCR model is fairly large, the first load may take a few seconds depending on network speed.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -87,7 +87,6 @@
       </main>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
     <script type="module" src="./scripts/main.js"></script>
   </body>
 </html>

--- a/scripts/tesseract-loader.js
+++ b/scripts/tesseract-loader.js
@@ -1,0 +1,155 @@
+const TESSERACT_SOURCES = [
+  {
+    name: 'jsdelivr',
+    displayName: 'jsDelivr',
+    scriptUrl: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js',
+    assetBaseUrl: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/',
+    failureStatus: {
+      status: 'loading',
+      message: 'Retrying OCR engine download from an alternate CDN',
+      progress: 0.18,
+    },
+  },
+  {
+    name: 'cdnjs',
+    displayName: 'cdnjs',
+    scriptUrl: 'https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/5.0.0/tesseract.min.js',
+    assetBaseUrl: 'https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/5.0.0/',
+    failureStatus: {
+      status: 'loading',
+      message: 'Retrying OCR engine download from an alternate CDN',
+      progress: 0.18,
+    },
+  },
+  {
+    name: 'unpkg',
+    displayName: 'unpkg',
+    scriptUrl: 'https://unpkg.com/tesseract.js@5/dist/tesseract.min.js',
+    assetBaseUrl: 'https://unpkg.com/tesseract.js@5/dist/',
+    failureStatus: {
+      status: 'loading',
+      message: 'Retrying OCR engine download from an alternate CDN',
+      progress: 0.18,
+    },
+  },
+];
+
+let loadPromise = null;
+let selectedSource = null;
+
+function isTesseractReady() {
+  return Boolean(globalThis.Tesseract && typeof globalThis.Tesseract.createWorker === 'function');
+}
+
+function hasDOM() {
+  return typeof document !== 'undefined' && typeof document.createElement === 'function';
+}
+
+function notify(reportStatus, state) {
+  if (!state || typeof reportStatus !== 'function') {
+    return;
+  }
+  try {
+    reportStatus(state);
+  } catch (error) {
+    console.error('Status listener failed', error);
+  }
+}
+
+function appendScript(source) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = source.scriptUrl;
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.onload = () => resolve(script);
+    script.onerror = (event) => {
+      script.remove();
+      const error = new Error(`Failed to load script: ${source.scriptUrl}`);
+      error.event = event;
+      reject(error);
+    };
+    document.head.appendChild(script);
+  });
+}
+
+async function attemptLoadFromSource(source, reportStatus) {
+  notify(reportStatus, {
+    status: 'loading',
+    message: `Loading OCR engine via ${source.displayName}`,
+    progress: 0.05,
+  });
+
+  await appendScript(source);
+
+  if (!isTesseractReady()) {
+    throw new Error(`Tesseract.js did not expose a global after loading from ${source.displayName}`);
+  }
+
+  notify(reportStatus, {
+    status: 'loading',
+    message: 'OCR engine ready',
+    progress: 0.12,
+  });
+
+  selectedSource = source;
+  return source;
+}
+
+export async function loadTesseract(reportStatus) {
+  if (isTesseractReady()) {
+    if (!selectedSource) {
+      selectedSource = TESSERACT_SOURCES[0];
+    }
+    return selectedSource;
+  }
+
+  if (!hasDOM()) {
+    throw new Error('Tesseract.js is unavailable and cannot be loaded in this environment.');
+  }
+
+  if (!loadPromise) {
+    loadPromise = (async () => {
+      let lastError = null;
+      for (const source of TESSERACT_SOURCES) {
+        try {
+          return await attemptLoadFromSource(source, reportStatus);
+        } catch (error) {
+          lastError = error;
+          console.warn(`Failed to load Tesseract.js from ${source.displayName}`, error);
+          notify(reportStatus, {
+            status: 'loading',
+            message: `Failed to load OCR engine from ${source.displayName}. Trying another mirror...`,
+            progress: 0.05,
+          });
+        }
+      }
+
+      const failure = new Error('Failed to load the OCR engine. Check your connection and try again.');
+      if (lastError) {
+        failure.cause = lastError;
+      }
+      throw failure;
+    })().catch((error) => {
+      loadPromise = null;
+      throw error;
+    });
+  }
+
+  return loadPromise;
+}
+
+export function getWorkerSources() {
+  if (selectedSource) {
+    const remaining = TESSERACT_SOURCES.filter((source) => source !== selectedSource);
+    return [selectedSource, ...remaining];
+  }
+  return [...TESSERACT_SOURCES];
+}
+
+export function __resetForTests() {
+  loadPromise = null;
+  selectedSource = null;
+}
+
+export { TESSERACT_SOURCES };


### PR DESCRIPTION
## Summary
- remove the bundled Tesseract.js assets and introduce a loader that pulls the library from jsDelivr, cdnjs, or unpkg at runtime
- update the OCR worker bootstrap to use the selected mirror, guard misconfigured sources, and surface CDN fallback status updates
- adjust the OCR tests to mock the loader and confirm CDN fallback behaviour, and document the CDN-based loading approach

## Testing
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68cd4ca0277c8322bdd8ed5c7ddab0d2