### PR TITLE
Generate OCR assets from dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ ENV/
 
 # Logs
 *.log
+
+# Generated OCR assets (copied from node_modules during install)
+public/vendor/tesseract/*
+!public/vendor/tesseract/README.md

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ loaded via WebAssembly, all computation stays on-device, and encounter history i
 - 🎥 **Live camera scanning** – request the rear camera, capture frames every few seconds, and highlight detected plates.
 - 🖼 **Still image processing** – upload a photo when camera permissions are unavailable.
 - 📊 **Local stats** – encounters are aggregated in `localStorage`, can be exported as CSV, and cleared at any time.
-- 🌐 **Static hosting** – the project ships as plain HTML/CSS/JS and loads Tesseract.js from multiple CDNs at runtime so it works on
-  GitHub Pages without installing Node packages.
+- 🌐 **Static hosting** – the project ships as plain HTML/CSS/JS with the OCR engine bundled locally and optional CDN fallbacks, so
+  it works on GitHub Pages without installing Node packages.
 
 ## Getting Started
 
@@ -38,6 +38,11 @@ npm run test:run   # execute the unit test suite once
 
 Use `npm test` if you prefer to keep Vitest running in watch mode.
 
+Running `npm install` also copies the Tesseract runtime, worker, and English
+language data from `node_modules` into `public/vendor/tesseract` so the app can
+load them without relying on third-party CDNs. If you ever need to refresh the
+local assets manually, run `npm run prepare:ocr`.
+
 On iOS devices you must access the site over HTTPS (GitHub Pages does this automatically). When testing locally with a phone,
 use a tool that provides HTTPS tunnelling (for example, `ngrok`) or host the static files from a service that offers HTTPS.
 
@@ -61,7 +66,7 @@ DEV_PLAN.md         # Development notes from the original project
 
 ## How it works
 
-- `scripts/ocr.js` dynamically loads the Tesseract.js library from multiple CDN mirrors and keeps a single worker alive to process frames.
+- `scripts/ocr.js` dynamically loads the Tesseract.js library from a local bundle (with CDN mirrors as fallbacks) and keeps a single worker alive to process frames.
 - `scripts/camera.js` captures frames from `getUserMedia`, throttles recognition, and forwards detections.
 - `scripts/store.js` tracks encounter history in `localStorage` and exposes helpers for exporting or clearing data.
 - `scripts/main.js` wires the UI, camera controller, store updates, and still image uploads together.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "plate-scanner",
       "version": "0.1.0",
+      "dependencies": {
+        "@tesseract.js-data/eng": "^1.0.0",
+        "tesseract.js": "^5.1.1"
+      },
       "devDependencies": {
         "@vitest/coverage-v8": "^1.6.0",
         "jsdom": "^24.0.0",
@@ -968,6 +972,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tesseract.js-data/eng": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tesseract.js-data/eng/-/eng-1.0.0.tgz",
+      "integrity": "sha512-mbTumm6KQPUHyzTPQaF3ObXYnx0SqqfV2nabqFVQBwD6Kl7PhGSLSzOlfFTWy0P3BjghaSKA2W9GB19Jk+ZcTg==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1148,6 +1158,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -1771,6 +1787,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1789,6 +1811,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -1809,6 +1837,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2103,6 +2137,48 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -2163,6 +2239,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/p-limit": {
@@ -2336,6 +2421,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
     },
     "node_modules/requires-port": {
@@ -2538,6 +2629,31 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tesseract.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-5.1.1.tgz",
+      "integrity": "sha512-lzVl/Ar3P3zhpUT31NjqeCo1f+D5+YfpZ5J62eo2S14QNVOmHBTtbchHm/YAbOOOzCegFnKf4B3Qih9LuldcYQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-electron": "^2.2.2",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^5.1.1",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.1.1.tgz",
+      "integrity": "sha512-KX3bYSU5iGcO1XJa+QGPbi+Zjo2qq6eBhNjSGR5E5q0JtzkoipJKOUQD7ph8kFyteCEfEQ0maWLu8MCXtvX5uQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -2810,6 +2926,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -2947,6 +3069,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,18 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepare:ocr": "node ./tools/prepare-tesseract-assets.js",
+    "postinstall": "npm run prepare:ocr"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^1.6.0",
     "jsdom": "^24.0.0",
     "vite": "^5.2.8",
     "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "@tesseract.js-data/eng": "^1.0.0",
+    "tesseract.js": "^5.1.1"
   }
 }

--- a/public/vendor/tesseract/README.md
+++ b/public/vendor/tesseract/README.md
@@ -1,0 +1,17 @@
+# Local OCR assets
+
+This directory is populated at install time by `npm run prepare:ocr`, which copies the
+Tesseract.js browser bundle, worker, WASM core, and English language data from the
+project's npm dependencies into `public/vendor/tesseract`.
+
+The generated files are intentionally ignored by Git to avoid storing large binary
+artifacts in the repository. Run `npm install` (or execute the script manually) to
+regenerate them whenever dependencies are updated.
+
+Licensing for these assets follows their upstream packages:
+
+- [`tesseract.js`](https://github.com/naptha/tesseract.js) (Apache-2.0)
+- [`tesseract.js-core`](https://github.com/naptha/tesseract.js-core) (Apache-2.0)
+- [`@tesseract.js-data/eng`](https://github.com/naptha/tesseract.js/tree/master/docs/tessdata) (Apache-2.0)
+
+Refer to the respective `LICENSE` files within `node_modules` for the complete terms.

--- a/scripts/ocr.js
+++ b/scripts/ocr.js
@@ -99,7 +99,7 @@ async function createWorkerInstance(Tesseract, workerOptions, reportStatus) {
 function getTesseract() {
   const tesseract = globalThis.Tesseract;
   if (!tesseract) {
-    throw new Error('Tesseract.js failed to load. Check your network connection.');
+    throw new Error('Tesseract.js failed to load. Check your installation or network connection.');
   }
   return tesseract;
 }
@@ -167,7 +167,7 @@ export async function ensureWorker(reportStatus) {
       }
 
       if (!worker) {
-        const failure = new Error('Failed to load OCR engine. Check your network connection and try again.');
+        const failure = new Error('Failed to load OCR engine. Check your installation or network connection and try again.');
         if (lastError) {
           failure.cause = lastError;
         }

--- a/scripts/tesseract-loader.js
+++ b/scripts/tesseract-loader.js
@@ -1,9 +1,38 @@
+function getBaseUrl() {
+  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.BASE_URL) {
+    return import.meta.env.BASE_URL;
+  }
+  return '/';
+}
+
+function withBase(path) {
+  const base = getBaseUrl();
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+const LOCAL_ASSET_BASE = withBase('vendor/tesseract/');
+
 const TESSERACT_SOURCES = [
+  {
+    name: 'local',
+    displayName: 'local assets',
+    scriptUrl: `${LOCAL_ASSET_BASE}tesseract.min.js`,
+    assetBaseUrl: LOCAL_ASSET_BASE,
+    langPathBaseUrl: `${LOCAL_ASSET_BASE}langs/`,
+    failureStatus: {
+      status: 'loading',
+      message: 'Retrying OCR engine download from an alternate source',
+      progress: 0.18,
+    },
+  },
   {
     name: 'jsdelivr',
     displayName: 'jsDelivr',
     scriptUrl: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js',
     assetBaseUrl: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/',
+    langPathBaseUrl: 'https://cdn.jsdelivr.net/npm/@tesseract.js-data/eng/4.0.0',
     failureStatus: {
       status: 'loading',
       message: 'Retrying OCR engine download from an alternate CDN',
@@ -15,6 +44,7 @@ const TESSERACT_SOURCES = [
     displayName: 'cdnjs',
     scriptUrl: 'https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/5.0.0/tesseract.min.js',
     assetBaseUrl: 'https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/5.0.0/',
+    langPathBaseUrl: 'https://tessdata.projectnaptha.com/4.0.0',
     failureStatus: {
       status: 'loading',
       message: 'Retrying OCR engine download from an alternate CDN',
@@ -26,6 +56,7 @@ const TESSERACT_SOURCES = [
     displayName: 'unpkg',
     scriptUrl: 'https://unpkg.com/tesseract.js@5/dist/tesseract.min.js',
     assetBaseUrl: 'https://unpkg.com/tesseract.js@5/dist/',
+    langPathBaseUrl: 'https://unpkg.com/@tesseract.js-data/eng@1.0.0/4.0.0',
     failureStatus: {
       status: 'loading',
       message: 'Retrying OCR engine download from an alternate CDN',

--- a/tools/prepare-tesseract-assets.js
+++ b/tools/prepare-tesseract-assets.js
@@ -1,0 +1,95 @@
+import { constants as fsConstants, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+const vendorRoot = path.join(projectRoot, 'public', 'vendor', 'tesseract');
+const langRoot = path.join(vendorRoot, 'langs');
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath, fsConstants.R_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function resolveLanguageSource() {
+  const langPackageRoot = path.join(projectRoot, 'node_modules', '@tesseract.js-data', 'eng');
+  const candidates = ['4.0.0_best_int', '4.0.0'];
+
+  for (const candidate of candidates) {
+    const candidatePath = path.join(langPackageRoot, candidate, 'eng.traineddata.gz');
+    if (await pathExists(candidatePath)) {
+      return {
+        source: candidatePath,
+        description: `English traineddata (${candidate})`,
+      };
+    }
+  }
+
+  throw new Error(
+    'Unable to locate eng.traineddata.gz in @tesseract.js-data/eng. Ensure the package is installed.',
+  );
+}
+
+async function copyAsset({ source, destination, description }) {
+  if (!(await pathExists(source))) {
+    throw new Error(`Missing ${description} at ${source}. Did npm install finish successfully?`);
+  }
+
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.copyFile(source, destination);
+  return destination;
+}
+
+async function main() {
+  const assets = [
+    {
+      source: path.join(projectRoot, 'node_modules', 'tesseract.js', 'dist', 'tesseract.min.js'),
+      destination: path.join(vendorRoot, 'tesseract.min.js'),
+      description: 'Tesseract.js browser bundle',
+    },
+    {
+      source: path.join(projectRoot, 'node_modules', 'tesseract.js', 'dist', 'worker.min.js'),
+      destination: path.join(vendorRoot, 'worker.min.js'),
+      description: 'Tesseract.js web worker',
+    },
+    {
+      source: path.join(projectRoot, 'node_modules', 'tesseract.js-core', 'tesseract-core.wasm.js'),
+      destination: path.join(vendorRoot, 'tesseract-core.wasm.js'),
+      description: 'Tesseract core loader',
+    },
+    {
+      source: path.join(projectRoot, 'node_modules', 'tesseract.js-core', 'tesseract-core.wasm'),
+      destination: path.join(vendorRoot, 'tesseract-core.wasm'),
+      description: 'Tesseract core WASM binary',
+    },
+  ];
+
+  const languageSource = await resolveLanguageSource();
+  assets.push({
+    source: languageSource.source,
+    destination: path.join(langRoot, 'eng.traineddata.gz'),
+    description: languageSource.description,
+  });
+
+  const copied = [];
+  for (const asset of assets) {
+    const destination = await copyAsset(asset);
+    copied.push(destination);
+  }
+
+  const relativePaths = copied.map((item) => path.relative(projectRoot, item));
+  console.log(`Prepared ${relativePaths.length} Tesseract asset${relativePaths.length === 1 ? '' : 's'}:\n - ${relativePaths.join('\n - ')}`);
+}
+
+main().catch((error) => {
+  console.error('\nFailed to prepare local Tesseract assets.');
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- replace the committed Tesseract binaries with an install-time copy script and ignore the generated assets
- point CDN fallbacks to hosted language data while documenting the local asset workflow
- add the @tesseract.js-data/eng dependency with a postinstall hook so npm install refreshes the OCR bundle

## Testing
- npm run test:run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd58c8e0088322b3327c3bc736da20