### PR TITLE
Load FastALPR assets from configurable sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,12 @@ ENV/
 # Generated OCR assets (copied from node_modules during install)
 public/vendor/tesseract/*
 !public/vendor/tesseract/README.md
+
+# Generated FastALPR models (downloaded separately)
+public/vendor/fastalpr/*
+!public/vendor/fastalpr/README.md
+!public/vendor/fastalpr/*.yaml
+
+# ONNX Runtime Web binaries (copied from node_modules during install)
+public/vendor/onnxruntime/*
+!public/vendor/onnxruntime/README.md

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PassingPlates Web
 
-PassingPlates runs entirely in the browser so it can be hosted on GitHub Pages and opened from iOS Safari. The OCR model is
-loaded via WebAssembly, all computation stays on-device, and encounter history is persisted locally in the browser.
+PassingPlates runs entirely in the browser so it can be hosted on GitHub Pages and opened from iOS Safari. The FastALPR stack
+is loaded via WebAssembly, all computation stays on-device, and encounter history is persisted locally in the browser.
 
 ## Features
 
-- 🔍 **On-device OCR** – [Tesseract.js](https://github.com/naptha/tesseract.js) runs in the browser via WebAssembly; no server is
-  required.
+- 🔍 **On-device ALPR** – a FastALPR pipeline (YOLOv9-lite detector + MobileViT OCR via `onnxruntime-web`) runs entirely in the
+  browser; no server is required.
 - 🎥 **Live camera scanning** – request the rear camera, capture frames every few seconds, and highlight detected plates.
 - 🖼 **Still image processing** – upload a photo when camera permissions are unavailable.
 - 📊 **Local stats** – encounters are aggregated in `localStorage`, can be exported as CSV, and cleared at any time.
@@ -38,10 +38,48 @@ npm run test:run   # execute the unit test suite once
 
 Use `npm test` if you prefer to keep Vitest running in watch mode.
 
-Running `npm install` also copies the Tesseract runtime, worker, and English
-language data from `node_modules` into `public/vendor/tesseract` so the app can
-load them without relying on third-party CDNs. If you ever need to refresh the
-local assets manually, run `npm run prepare:ocr`.
+Running `npm install` also copies the Tesseract runtime, English language data,
+and ONNX Runtime binaries into the `public/vendor` folder so the app can load
+them without relying on third-party CDNs. The FastALPR ONNX models are not
+committed to git; provide them manually or configure the download helpers before
+running `npm run prepare:alpr`. If you ever need to refresh the local assets
+manually, run `npm run prepare:ocr` and `npm run prepare:alpr`.
+
+### FastALPR asset setup
+
+The FastALPR detector and OCR models are several megabytes each, so they are not
+stored in the repository. Use one of the following approaches before serving the
+app:
+
+1. **Automatic download during install** – set either
+   `FASTALPR_ASSET_BASE_URL=https://example.com/fastalpr/` or the individual
+   `FASTALPR_DETECTOR_URL` / `FASTALPR_OCR_URL` environment variables, then run
+   `npm run prepare:alpr`. The script saves the models into
+   `public/vendor/fastalpr/` and copies the ONNX Runtime Web binaries from
+   `node_modules`.
+2. **Manual placement** – download
+   `yolo-v9-t-384-license-plates-end2end.onnx` and
+   `global_mobile_vit_v2_ocr.onnx` yourself and place them in
+   `public/vendor/fastalpr/` alongside the provided YAML config.
+3. **CDN hosting** – host the models externally and expose them via
+   `window.fastAlprAssetConfig` before the app scripts load:
+
+   ```html
+   <script>
+     window.fastAlprAssetConfig = {
+       modelBaseUrl: 'https://cdn.example.com/fastalpr/',
+       onnxRuntimeBaseUrls: [
+         'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/',
+       ],
+   };
+   </script>
+   ```
+
+   You can also provide explicit `detectorModelUrls`, `ocrModelUrls`, or
+   `onnxRuntimeScriptUrls` arrays if the models or runtime live at different
+   locations. The loader will try each entry in order and fall back to the
+   bundled paths if available. When no local ONNX Runtime assets are present,
+   the app automatically falls back to the jsDelivr or unpkg CDNs.
 
 On iOS devices you must access the site over HTTPS (GitHub Pages does this automatically). When testing locally with a phone,
 use a tool that provides HTTPS tunnelling (for example, `ngrok`) or host the static files from a service that offers HTTPS.
@@ -66,7 +104,8 @@ DEV_PLAN.md         # Development notes from the original project
 
 ## How it works
 
-- `scripts/ocr.js` dynamically loads the Tesseract.js library from a local bundle (with CDN mirrors as fallbacks) and keeps a single worker alive to process frames.
+- `scripts/fastalpr-engine.js` loads the ONNX detector + OCR models, performs preprocessing/postprocessing, and returns high-confidence UK plate candidates.
+- `scripts/recognition-engine.js` orchestrates FastALPR and falls back to the legacy Tesseract worker if the models fail to load.
 - `scripts/camera.js` captures frames from `getUserMedia`, throttles recognition, and forwards detections.
 - `scripts/store.js` tracks encounter history in `localStorage` and exposes helpers for exporting or clearing data.
 - `scripts/main.js` wires the UI, camera controller, store updates, and still image uploads together.
@@ -74,7 +113,7 @@ DEV_PLAN.md         # Development notes from the original project
 ## Browser Support
 
 - Modern Chromium, Firefox, and Safari browsers that support ES modules and `getUserMedia` (iOS 15+).
-- Because the OCR model is fairly large, the first load may take a few seconds depending on network speed.
+- Because the ONNX models are several megabytes, the first load may take a few seconds depending on network speed.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -34,10 +34,10 @@
         </section>
 
         <section class="section-card" id="debug-section">
-          <h2>OCR debug info</h2>
-          <p>Live updates from the OCR worker to help diagnose loading or initialization issues.</p>
+          <h2>ALPR debug info</h2>
+          <p>Live updates from the recognition engine to help diagnose loading or initialization issues.</p>
           <ul id="debug-log" class="debug-log">
-            <li id="debug-log-empty" class="debug-log__item debug-log__item--empty">No OCR activity yet.</li>
+            <li id="debug-log-empty" class="debug-log__item debug-log__item--empty">No ALPR activity yet.</li>
           </ul>
         </section>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "plate-scanner",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@tesseract.js-data/eng": "^1.0.0",
+        "onnxruntime-web": "^1.22.0",
         "tesseract.js": "^5.1.1"
       },
       "devDependencies": {
@@ -671,6 +673,70 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.51.0.tgz",
@@ -984,6 +1050,15 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "1.6.1",
@@ -1518,6 +1593,12 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.2.10",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.2.10.tgz",
+      "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -1663,6 +1744,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1970,6 +2057,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -2241,6 +2334,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0.tgz",
+      "integrity": "sha512-vcuaNWgtF2dGQu/EP5P8UI5rEPEYqXG2sPPe5j9lg2TY/biJF8eWklTMwlDO08iuXq48xJo0awqIpK5mPG+IxA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0.tgz",
+      "integrity": "sha512-Ud/+EBo6mhuaQWt/OjaOk0iNWjXqJoeeMFr6xQEERZdIZH2OWpGzuujz7lfuOBjUa6TEE/sc4nb7Da5dNL34fg==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -2342,6 +2455,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -2384,6 +2503,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/psl": {
@@ -2741,6 +2884,12 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "prepare:ocr": "node ./tools/prepare-tesseract-assets.js",
-    "postinstall": "npm run prepare:ocr"
+    "prepare:alpr": "node ./tools/prepare-alpr-assets.js",
+    "postinstall": "npm run prepare:ocr && npm run prepare:alpr"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^1.6.0",
@@ -22,6 +23,7 @@
   },
   "dependencies": {
     "@tesseract.js-data/eng": "^1.0.0",
+    "onnxruntime-web": "^1.22.0",
     "tesseract.js": "^5.1.1"
   }
 }

--- a/public/vendor/fastalpr/README.md
+++ b/public/vendor/fastalpr/README.md
@@ -1,0 +1,12 @@
+# FastALPR assets
+
+The FastALPR ONNX models are not committed to the repository because they are
+large binary files. Place the following files in this directory when hosting the
+app:
+
+- `yolo-v9-t-384-license-plates-end2end.onnx`
+- `global_mobile_vit_v2_ocr.onnx`
+
+You can download them from your preferred storage location and either commit
+them to your deployment branch or host them on a CDN. See the project README
+for automated download options and configuration details.

--- a/public/vendor/fastalpr/global_mobile_vit_v2_ocr_config.yaml
+++ b/public/vendor/fastalpr/global_mobile_vit_v2_ocr_config.yaml
@@ -1,0 +1,12 @@
+# Config used for European countries
+
+# Max number of plate slots supported. This represents the number of model classification heads.
+max_plate_slots: 9
+# All the possible character set for the model output.
+alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_'
+# Padding character for plates which length is smaller than MAX_PLATE_SLOTS. It should still be present in the alphabet.
+pad_char: '_'
+# Image height which is fed to the model.
+img_height: 70
+# Image width which is fed to the model.
+img_width: 140

--- a/public/vendor/onnxruntime/README.md
+++ b/public/vendor/onnxruntime/README.md
@@ -1,0 +1,8 @@
+# ONNX Runtime Web assets
+
+The ONNX Runtime Web bundles (`ort.all.min.js` and associated WebAssembly
+binaries) are copied into this directory during development via
+`npm run prepare:alpr`. They are not committed to git to keep the repository
+lightweight. If you are deploying a static build, make sure these files are
+present in your published assets or configure the app to load ONNX Runtime from
+a CDN as described in the README.

--- a/scripts/assetPaths.js
+++ b/scripts/assetPaths.js
@@ -1,0 +1,18 @@
+function getBaseUrl() {
+  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.BASE_URL) {
+    return import.meta.env.BASE_URL;
+  }
+  return '/';
+}
+
+export function withBase(path) {
+  const base = getBaseUrl();
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+export function getBasePath() {
+  const base = withBase('');
+  return base.endsWith('/') ? base : `${base}/`;
+}

--- a/scripts/fastalpr-engine.js
+++ b/scripts/fastalpr-engine.js
@@ -1,0 +1,562 @@
+import { withBase } from './assetPaths.js';
+import { ensureOrtRuntime } from './fastalpr-loader.js';
+import { wordsToDetections } from './detections.js';
+
+const DETECTOR_MODEL_FILENAME = 'yolo-v9-t-384-license-plates-end2end.onnx';
+const OCR_MODEL_FILENAME = 'global_mobile_vit_v2_ocr.onnx';
+const OCR_CONFIG_FILENAME = 'global_mobile_vit_v2_ocr_config.yaml';
+
+function toArray(value) {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function trimValue(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function ensureTrailingSlash(value) {
+  if (!value) {
+    return '';
+  }
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function dedupeStrings(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of values) {
+    const trimmed = trimValue(value);
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function buildCandidateList(overrides, baseUrls, filename) {
+  const candidates = [];
+  for (const override of overrides) {
+    const trimmed = trimValue(override);
+    if (trimmed) {
+      candidates.push(trimmed);
+    }
+  }
+  for (const base of baseUrls) {
+    const normalizedBase = ensureTrailingSlash(trimValue(base));
+    if (normalizedBase) {
+      candidates.push(`${normalizedBase}${filename}`);
+    }
+  }
+  return dedupeStrings(candidates);
+}
+
+function getAssetConfig() {
+  const config = globalThis.fastAlprAssetConfig || {};
+
+  const baseOverrides = toArray(config.modelBaseUrls ?? config.modelBaseUrl);
+  baseOverrides.push(withBase('vendor/fastalpr/'));
+  const normalizedBases = dedupeStrings(baseOverrides.map((base) => ensureTrailingSlash(trimValue(base))).filter(Boolean));
+
+  const detectorOverrides = toArray(config.detectorModelUrls ?? config.detectorModelUrl);
+  const ocrOverrides = toArray(config.ocrModelUrls ?? config.ocrModelUrl);
+  const configOverrides = toArray(config.ocrConfigUrls ?? config.ocrConfigUrl);
+
+  const detectorModelUrls = buildCandidateList(detectorOverrides, normalizedBases, DETECTOR_MODEL_FILENAME);
+  const ocrModelUrls = buildCandidateList(ocrOverrides, normalizedBases, OCR_MODEL_FILENAME);
+
+  const configCandidates = [
+    ...configOverrides,
+    ...normalizedBases.map((base) => `${ensureTrailingSlash(base)}${OCR_CONFIG_FILENAME}`),
+    withBase(`vendor/fastalpr/${OCR_CONFIG_FILENAME}`),
+  ];
+  const ocrConfigUrls = dedupeStrings(configCandidates);
+
+  return {
+    detectorModelUrls,
+    ocrModelUrls,
+    ocrConfigUrls,
+  };
+}
+
+const DETECTION_CONFIDENCE_THRESHOLD = 0.4;
+const RECOGNITION_CONFIDENCE_THRESHOLD = 0.35;
+const DETECTION_WEIGHT = 0.6;
+const RECOGNITION_WEIGHT = 0.4;
+const BOX_EXPANSION_X = 0.1;
+const BOX_EXPANSION_Y = 0.2;
+
+let enginePromise = null;
+
+function notify(reportStatus, state) {
+  if (typeof reportStatus === 'function' && state) {
+    try {
+      reportStatus(state);
+    } catch (error) {
+      console.error('Status listener failed', error);
+    }
+  }
+}
+
+async function fetchArrayBufferFromUrl(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response.arrayBuffer();
+}
+
+async function fetchTextFromUrl(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response.text();
+}
+
+async function fetchWithFallback(urls, loader, description) {
+  const candidates = toArray(urls);
+  const errors = [];
+  for (const candidate of candidates) {
+    const url = trimValue(candidate);
+    if (!url) {
+      continue;
+    }
+    try {
+      return await loader(url);
+    } catch (error) {
+      console.warn(`Failed to load ${description} from ${url}`, error);
+      errors.push({ url, error });
+    }
+  }
+
+  const detail = errors.length
+    ? errors.map((entry) => `${entry.url}: ${entry.error?.message || entry.error}`).join('; ')
+    : 'No candidate URLs were provided.';
+
+  throw new Error(`Unable to load ${description}. ${detail}`);
+}
+
+function parseYamlConfig(text) {
+  const result = {};
+  const lines = text.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex === -1) {
+      continue;
+    }
+    const key = line.slice(0, separatorIndex).trim();
+    let value = line.slice(separatorIndex + 1).trim();
+    if (!key) {
+      continue;
+    }
+    if (value.startsWith("'") && value.endsWith("'")) {
+      value = value.slice(1, -1);
+    } else if (value === 'true' || value === 'false') {
+      value = value === 'true';
+    } else if (!Number.isNaN(Number(value))) {
+      value = Number(value);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function createCanvas(width, height) {
+  if (typeof OffscreenCanvas === 'function') {
+    return new OffscreenCanvas(width, height);
+  }
+  if (typeof document === 'undefined' || typeof document.createElement !== 'function') {
+    throw new Error('Canvas is not supported in this environment.');
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+function get2dContext(canvas) {
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) {
+    throw new Error('Failed to acquire 2D canvas context.');
+  }
+  return ctx;
+}
+
+function clamp(value, min, max) {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+function combineConfidence(detectionScore, recognitionScore) {
+  const detectionPercent = Number.isFinite(detectionScore) ? detectionScore * 100 : 0;
+  const recognitionPercent = Number.isFinite(recognitionScore) ? recognitionScore * 100 : 0;
+  const combined = detectionPercent * DETECTION_WEIGHT + recognitionPercent * RECOGNITION_WEIGHT;
+  return clamp(combined, 0, 100);
+}
+
+function decodeOcrOutput(tensor, config) {
+  const data = tensor.data;
+  const dims = tensor.dims || [];
+  const batchSize = dims[0] && dims[0] > 0 ? dims[0] : 1;
+  const maxSlots = Number(config.max_plate_slots) || 0;
+  const alphabet = typeof config.alphabet === 'string' ? config.alphabet.split('') : [];
+  const vocabSize = alphabet.length;
+  if (!maxSlots || !vocabSize) {
+    return [];
+  }
+  const stride = maxSlots * vocabSize;
+  const results = [];
+  for (let batch = 0; batch < batchSize; batch += 1) {
+    const start = batch * stride;
+    const characters = [];
+    const confidences = [];
+    for (let slot = 0; slot < maxSlots; slot += 1) {
+      const slotStart = start + slot * vocabSize;
+      let bestIdx = 0;
+      let bestValue = Number.NEGATIVE_INFINITY;
+      for (let charIdx = 0; charIdx < vocabSize; charIdx += 1) {
+        const value = data[slotStart + charIdx];
+        if (value > bestValue) {
+          bestValue = value;
+          bestIdx = charIdx;
+        }
+      }
+      characters.push(alphabet[bestIdx] ?? '');
+      confidences.push(bestValue);
+    }
+    results.push({ text: characters.join(''), confidences });
+  }
+  return results;
+}
+
+class FastAlprEngine {
+  constructor(ort, detectionSession, recognitionSession, config) {
+    this.ort = ort;
+    this.detectionSession = detectionSession;
+    this.recognitionSession = recognitionSession;
+    this.config = config;
+
+    const detectionInputName = detectionSession.inputNames?.[0] || detectionSession.session?.inputNames?.[0];
+    this.detectionInputName = detectionInputName;
+    const detectionOutputName = detectionSession.outputNames?.[0] || detectionSession.session?.outputNames?.[0];
+    this.detectionOutputName = detectionOutputName;
+    const detectionMetadata = detectionSession.inputMetadata?.[detectionInputName];
+    this.detectionDims = detectionMetadata?.dimensions || detectionMetadata?.dims || detectionSession.input?.dims;
+
+    const recognitionInputName = recognitionSession.inputNames?.[0];
+    this.recognitionInputName = recognitionInputName;
+    const recognitionOutputName = recognitionSession.outputNames?.[0];
+    this.recognitionOutputName = recognitionOutputName;
+    const recognitionMetadata = recognitionSession.inputMetadata?.[recognitionInputName];
+    this.recognitionDims = recognitionMetadata?.dimensions || recognitionMetadata?.dims;
+
+    const targetHeight = this.detectionDims?.[2] || 384;
+    const targetWidth = this.detectionDims?.[3] || 384;
+    this.letterboxCanvas = createCanvas(targetWidth, targetHeight);
+    this.letterboxCtx = get2dContext(this.letterboxCanvas);
+
+    this.cropCanvas = createCanvas(1, 1);
+    this.cropCtx = get2dContext(this.cropCanvas);
+
+    const recognitionWidth = Number(config.img_width) || 140;
+    const recognitionHeight = Number(config.img_height) || 70;
+    this.recognitionCanvas = createCanvas(recognitionWidth, recognitionHeight);
+    this.recognitionCtx = get2dContext(this.recognitionCanvas);
+
+    this.padChar = typeof config.pad_char === 'string' ? config.pad_char : '_';
+    this.alphabet = typeof config.alphabet === 'string' ? config.alphabet.split('') : [];
+    this.channels = config.image_color_mode === 'rgb' ? 3 : 1;
+  }
+
+  preprocessDetection(canvas) {
+    const width = canvas.width;
+    const height = canvas.height;
+    if (!width || !height) {
+      return null;
+    }
+
+    const targetHeight = this.letterboxCanvas.height;
+    const targetWidth = this.letterboxCanvas.width;
+    const ctx = this.letterboxCtx;
+
+    ctx.save();
+    ctx.fillStyle = '#727272';
+    ctx.fillRect(0, 0, targetWidth, targetHeight);
+    const scale = Math.min(targetWidth / width, targetHeight / height);
+    const newWidth = Math.round(width * scale);
+    const newHeight = Math.round(height * scale);
+    const dx = (targetWidth - newWidth) / 2;
+    const dy = (targetHeight - newHeight) / 2;
+    ctx.imageSmoothingEnabled = true;
+    ctx.drawImage(canvas, 0, 0, width, height, dx, dy, newWidth, newHeight);
+    ctx.restore();
+
+    const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
+    const { data } = imageData;
+    const planeSize = targetWidth * targetHeight;
+    const tensorData = new Float32Array(planeSize * 3);
+    for (let i = 0; i < planeSize; i += 1) {
+      const offset = i * 4;
+      const r = data[offset] / 255;
+      const g = data[offset + 1] / 255;
+      const b = data[offset + 2] / 255;
+      tensorData[i] = r;
+      tensorData[i + planeSize] = g;
+      tensorData[i + 2 * planeSize] = b;
+    }
+    const inputTensor = new this.ort.Tensor('float32', tensorData, [1, 3, targetHeight, targetWidth]);
+    return {
+      tensor: inputTensor,
+      ratio: [scale, scale],
+      padding: [dx, dy],
+    };
+  }
+
+  decodeDetections(outputTensor, ratio, padding, frameWidth, frameHeight) {
+    if (!outputTensor) {
+      return [];
+    }
+    const data = outputTensor.data;
+    const dims = outputTensor.dims || [];
+    const rowSize = dims[1] && dims[1] > 0 ? dims[1] : 7;
+    const totalRows = dims[0] && dims[0] > 0 ? dims[0] : data.length / rowSize;
+    const [scaleX, scaleY] = ratio;
+    const [padX, padY] = padding;
+    const detections = [];
+    for (let row = 0; row < totalRows; row += 1) {
+      const offset = row * rowSize;
+      const score = data[offset + 6];
+      if (!Number.isFinite(score) || score < DETECTION_CONFIDENCE_THRESHOLD) {
+        continue;
+      }
+      const x1 = (data[offset + 1] - padX) / scaleX;
+      const y1 = (data[offset + 2] - padY) / scaleY;
+      const x2 = (data[offset + 3] - padX) / scaleX;
+      const y2 = (data[offset + 4] - padY) / scaleY;
+
+      let left = clamp(Math.min(x1, x2), 0, frameWidth);
+      let right = clamp(Math.max(x1, x2), 0, frameWidth);
+      let top = clamp(Math.min(y1, y2), 0, frameHeight);
+      let bottom = clamp(Math.max(y1, y2), 0, frameHeight);
+
+      const width = right - left;
+      const height = bottom - top;
+      if (width <= 1 || height <= 1) {
+        continue;
+      }
+
+      const expandX = width * BOX_EXPANSION_X;
+      const expandY = height * BOX_EXPANSION_Y;
+      left = clamp(left - expandX / 2, 0, frameWidth);
+      right = clamp(right + expandX / 2, 0, frameWidth);
+      top = clamp(top - expandY / 2, 0, frameHeight);
+      bottom = clamp(bottom + expandY / 2, 0, frameHeight);
+
+      detections.push({
+        x0: left,
+        y0: top,
+        x1: right,
+        y1: bottom,
+        score,
+      });
+    }
+    return detections;
+  }
+
+  buildRecognitionTensor(canvas, box) {
+    const width = Math.max(1, Math.round(box.x1 - box.x0));
+    const height = Math.max(1, Math.round(box.y1 - box.y0));
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width < 1 || height < 1) {
+      return null;
+    }
+
+    this.cropCanvas.width = width;
+    this.cropCanvas.height = height;
+    const cropCtx = this.cropCtx;
+    cropCtx.clearRect(0, 0, width, height);
+    cropCtx.drawImage(canvas, box.x0, box.y0, box.x1 - box.x0, box.y1 - box.y0, 0, 0, width, height);
+
+    const targetWidth = this.recognitionCanvas.width;
+    const targetHeight = this.recognitionCanvas.height;
+    const recognitionCtx = this.recognitionCtx;
+    recognitionCtx.clearRect(0, 0, targetWidth, targetHeight);
+    recognitionCtx.imageSmoothingEnabled = true;
+    recognitionCtx.drawImage(this.cropCanvas, 0, 0, width, height, 0, 0, targetWidth, targetHeight);
+
+    const imageData = recognitionCtx.getImageData(0, 0, targetWidth, targetHeight);
+    const { data } = imageData;
+    const planeSize = targetWidth * targetHeight;
+    if (this.channels === 1) {
+      const grayscale = new Uint8Array(planeSize);
+      for (let i = 0; i < planeSize; i += 1) {
+        const offset = i * 4;
+        const r = data[offset];
+        const g = data[offset + 1];
+        const b = data[offset + 2];
+        const gray = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
+        grayscale[i] = gray;
+      }
+      return new this.ort.Tensor('uint8', grayscale, [1, targetHeight, targetWidth, 1]);
+    }
+
+    const tensorData = new Uint8Array(planeSize * 3);
+    for (let i = 0; i < planeSize; i += 1) {
+      const offset = i * 4;
+      tensorData[i] = data[offset];
+      tensorData[i + planeSize] = data[offset + 1];
+      tensorData[i + planeSize * 2] = data[offset + 2];
+    }
+    return new this.ort.Tensor('uint8', tensorData, [1, targetHeight, targetWidth, 3]);
+  }
+
+  async recogniseCandidate(canvas, box) {
+    const inputTensor = this.buildRecognitionTensor(canvas, box);
+    if (!inputTensor) {
+      return null;
+    }
+    const feeds = { [this.recognitionInputName]: inputTensor };
+    const outputMap = await this.recognitionSession.run(feeds);
+    const outputTensor = outputMap[this.recognitionOutputName];
+    const [result] = decodeOcrOutput(outputTensor, this.config);
+    if (!result || !result.text) {
+      return null;
+    }
+    const rawText = result.text.replace(/\0/g, '');
+    const cleaned = rawText.split(this.padChar).join('').trim();
+    if (!cleaned) {
+      return null;
+    }
+    const confidences = Array.isArray(result.confidences) ? result.confidences : [];
+    const meaningful = [];
+    for (let i = 0; i < confidences.length; i += 1) {
+      if (result.text[i] && result.text[i] !== this.padChar) {
+        meaningful.push(confidences[i]);
+      }
+    }
+    const averageConfidence = meaningful.length
+      ? meaningful.reduce((sum, value) => sum + value, 0) / meaningful.length
+      : 0;
+    if (!Number.isFinite(averageConfidence) || averageConfidence < RECOGNITION_CONFIDENCE_THRESHOLD) {
+      return null;
+    }
+    return {
+      text: cleaned,
+      averageConfidence,
+    };
+  }
+
+  async process(canvas, source, reportStatus) {
+    const width = canvas?.width;
+    const height = canvas?.height;
+    if (!width || !height) {
+      return [];
+    }
+
+    notify(reportStatus, { status: 'processing' });
+
+    const detectionInput = this.preprocessDetection(canvas);
+    if (!detectionInput) {
+      notify(reportStatus, { status: 'ready' });
+      return [];
+    }
+
+    const feeds = { [this.detectionInputName]: detectionInput.tensor };
+    const outputMap = await this.detectionSession.run(feeds);
+    const outputTensor = outputMap[this.detectionOutputName];
+    const candidates = this.decodeDetections(outputTensor, detectionInput.ratio, detectionInput.padding, width, height);
+    if (!candidates.length) {
+      notify(reportStatus, { status: 'ready' });
+      return [];
+    }
+
+    const words = [];
+    for (const candidate of candidates) {
+      const recognition = await this.recogniseCandidate(canvas, candidate);
+      if (!recognition) {
+        continue;
+      }
+      const baseConfidence = combineConfidence(candidate.score, recognition.averageConfidence);
+      words.push({
+        text: recognition.text,
+        confidence: baseConfidence,
+        bbox: {
+          x0: candidate.x0,
+          y0: candidate.y0,
+          x1: candidate.x1,
+          y1: candidate.y1,
+        },
+      });
+    }
+
+    const detections = wordsToDetections(words, width, height, source);
+    notify(reportStatus, { status: 'ready' });
+    return detections;
+  }
+}
+
+async function createFastAlprEngine(reportStatus) {
+  const ort = await ensureOrtRuntime((state) => notify(reportStatus, state));
+  const assetConfig = getAssetConfig();
+  notify(reportStatus, { status: 'loading', message: 'Fetching detector model', progress: 0.15 });
+  const [detectorBuffer, ocrBuffer, configText] = await Promise.all([
+    fetchWithFallback(assetConfig.detectorModelUrls, fetchArrayBufferFromUrl, 'FastALPR detector model'),
+    (async () => {
+      notify(reportStatus, { status: 'loading', message: 'Fetching OCR model', progress: 0.25 });
+      return fetchWithFallback(assetConfig.ocrModelUrls, fetchArrayBufferFromUrl, 'FastALPR OCR model');
+    })(),
+    (async () => {
+      notify(reportStatus, { status: 'loading', message: 'Loading OCR config', progress: 0.3 });
+      return fetchWithFallback(assetConfig.ocrConfigUrls, fetchTextFromUrl, 'FastALPR OCR config');
+    })(),
+  ]);
+
+  const config = parseYamlConfig(configText);
+
+  notify(reportStatus, { status: 'loading', message: 'Initialising detector', progress: 0.4 });
+  const detectionSession = await ort.InferenceSession.create(detectorBuffer, {
+    executionProviders: ['wasm'],
+    graphOptimizationLevel: 'all',
+  });
+
+  notify(reportStatus, { status: 'loading', message: 'Initialising recogniser', progress: 0.6 });
+  const recognitionSession = await ort.InferenceSession.create(ocrBuffer, {
+    executionProviders: ['wasm'],
+    graphOptimizationLevel: 'all',
+  });
+
+  notify(reportStatus, { status: 'ready', message: 'ALPR ready', progress: 1 });
+  return new FastAlprEngine(ort, detectionSession, recognitionSession, config);
+}
+
+export async function ensureFastAlpr(reportStatus) {
+  if (!enginePromise) {
+    enginePromise = createFastAlprEngine(reportStatus).catch((error) => {
+      enginePromise = null;
+      throw error;
+    });
+  }
+  return enginePromise;
+}
+
+export async function analyzeWithFastAlpr(canvas, source, reportStatus) {
+  const engine = await ensureFastAlpr(reportStatus);
+  return engine.process(canvas, source, reportStatus);
+}
+
+export function resetFastAlprForTests() {
+  enginePromise = null;
+}

--- a/scripts/fastalpr-loader.js
+++ b/scripts/fastalpr-loader.js
@@ -1,0 +1,175 @@
+import { withBase } from './assetPaths.js';
+
+const DEFAULT_ORT_VERSION = '1.22.0';
+
+let ortLoadPromise = null;
+
+function hasDom() {
+  return typeof document !== 'undefined' && typeof document.createElement === 'function';
+}
+
+function toArray(value) {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function trimValue(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function ensureTrailingSlash(value) {
+  if (!value) {
+    return '';
+  }
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function getOrtSources() {
+  const config = globalThis.fastAlprAssetConfig || {};
+  const sources = [];
+  const seen = new Set();
+
+  const addSource = ({ scriptUrl, wasmBaseUrl, label }) => {
+    const cleanedScriptUrl = trimValue(scriptUrl);
+    if (!cleanedScriptUrl || seen.has(cleanedScriptUrl)) {
+      return;
+    }
+    seen.add(cleanedScriptUrl);
+    let resolvedWasmBase = trimValue(wasmBaseUrl);
+    if (!resolvedWasmBase) {
+      const lastSlash = cleanedScriptUrl.lastIndexOf('/');
+      if (lastSlash !== -1) {
+        resolvedWasmBase = cleanedScriptUrl.slice(0, lastSlash + 1);
+      }
+    }
+    sources.push({
+      scriptUrl: cleanedScriptUrl,
+      wasmBaseUrl: resolvedWasmBase ? ensureTrailingSlash(resolvedWasmBase) : undefined,
+      label,
+    });
+  };
+
+  const addFromBase = (baseUrl, label) => {
+    const cleanedBase = ensureTrailingSlash(trimValue(baseUrl));
+    if (!cleanedBase) {
+      return;
+    }
+    addSource({
+      scriptUrl: `${cleanedBase}ort.all.min.js`,
+      wasmBaseUrl: cleanedBase,
+      label,
+    });
+  };
+
+  const customSources = toArray(config.onnxRuntimeSources);
+  for (const source of customSources) {
+    if (!source) {
+      continue;
+    }
+    if (typeof source === 'string') {
+      addFromBase(source, 'custom base');
+    } else if (typeof source === 'object') {
+      addSource({
+        scriptUrl: source.scriptUrl || source.url || source.src,
+        wasmBaseUrl: source.wasmBaseUrl || source.baseUrl,
+        label: source.label || 'custom source',
+      });
+    }
+  }
+
+  toArray(config.onnxRuntimeBaseUrls ?? config.onnxRuntimeBaseUrl).forEach((base) => {
+    addFromBase(base, 'custom base');
+  });
+
+  toArray(config.onnxRuntimeScriptUrls ?? config.onnxRuntimeScriptUrl).forEach((script) => {
+    addSource({
+      scriptUrl: script,
+      label: 'custom script',
+    });
+  });
+
+  addFromBase(withBase('vendor/onnxruntime/'), 'local vendor');
+  addFromBase(`https://cdn.jsdelivr.net/npm/onnxruntime-web@${DEFAULT_ORT_VERSION}/dist/`, 'jsDelivr CDN');
+  addFromBase(`https://unpkg.com/onnxruntime-web@${DEFAULT_ORT_VERSION}/dist/`, 'unpkg CDN');
+
+  return sources;
+}
+
+function appendScriptFromSource(source) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = source.scriptUrl;
+    script.async = true;
+    script.onload = () => resolve(script);
+    script.onerror = (event) => {
+      script.remove();
+      const error = new Error(`Failed to load ONNX Runtime script: ${source.scriptUrl}`);
+      error.event = event;
+      reject(error);
+    };
+    document.head.appendChild(script);
+  });
+}
+
+export async function ensureOrtRuntime(reportStatus) {
+  if (globalThis.ort && typeof globalThis.ort.InferenceSession === 'function') {
+    return globalThis.ort;
+  }
+
+  if (!hasDom()) {
+    throw new Error('ONNX Runtime requires a DOM environment.');
+  }
+
+  if (!ortLoadPromise) {
+    ortLoadPromise = (async () => {
+      const sources = getOrtSources();
+      const errors = [];
+
+      for (const source of sources) {
+        try {
+          if (typeof reportStatus === 'function') {
+            const label = source.label ? ` (${source.label})` : '';
+            reportStatus({ status: 'loading', message: `Loading ONNX Runtime${label}`, progress: 0.05 });
+          }
+          const scriptElement = await appendScriptFromSource(source);
+          const ort = globalThis.ort;
+          if (!ort || typeof ort.InferenceSession !== 'function') {
+            scriptElement.remove();
+            throw new Error('ONNX Runtime failed to expose a global `ort` namespace.');
+          }
+          ort.env.wasm = ort.env.wasm || {};
+          if (source.wasmBaseUrl) {
+            ort.env.wasm.wasmPaths = source.wasmBaseUrl;
+          }
+          if (typeof navigator !== 'undefined' && Number.isFinite(navigator.hardwareConcurrency)) {
+            const maxThreads = Math.max(1, Math.min(4, navigator.hardwareConcurrency));
+            ort.env.wasm.numThreads = maxThreads;
+          }
+          if (typeof reportStatus === 'function') {
+            reportStatus({ status: 'loading', message: 'ONNX Runtime ready', progress: 0.1 });
+          }
+          return ort;
+        } catch (error) {
+          console.warn(`Failed to load ONNX Runtime from ${source.scriptUrl}`, error);
+          errors.push({ source, error });
+        }
+      }
+
+      const details = errors
+        .map((entry) => `${entry.source.scriptUrl}: ${entry.error?.message || entry.error}`)
+        .join('; ');
+      throw new Error(`Unable to load ONNX Runtime from any configured source. ${details}`);
+    })().catch((error) => {
+      ortLoadPromise = null;
+      throw error;
+    });
+  }
+
+  return ortLoadPromise;
+}
+
+export function resetOrtLoaderForTests() {
+  ortLoadPromise = null;
+}

--- a/scripts/plateMatcher.js
+++ b/scripts/plateMatcher.js
@@ -1,5 +1,4 @@
-const UK_EU_PATTERN = /^[A-Z]{2}[0-9]{2}[A-Z]{3}$/;
-const GENERIC_PATTERN = /^[A-Z0-9]{5,8}$/;
+const UK_STANDARD_PATTERN = /^[A-Z]{2}[0-9]{2}[A-Z]{3}$/;
 
 export function normalizePlate(text) {
   return text.replace(/[^A-Z0-9]/gi, '').toUpperCase();
@@ -7,39 +6,22 @@ export function normalizePlate(text) {
 
 export function formatPlate(text) {
   const normalized = normalizePlate(text);
-  if (normalized.length === 7 && UK_EU_PATTERN.test(normalized)) {
+  if (UK_STANDARD_PATTERN.test(normalized)) {
     return `${normalized.slice(0, 2)}${normalized.slice(2, 4)} ${normalized.slice(4)}`;
-  }
-  if (normalized.length === 7) {
-    return `${normalized.slice(0, 4)} ${normalized.slice(4)}`;
-  }
-  if (normalized.length === 8) {
-    return `${normalized.slice(0, 4)} ${normalized.slice(4)}`;
   }
   return normalized;
 }
 
 export function isLikelyPlate(text) {
   const normalized = normalizePlate(text);
-  if (normalized.length < 5) {
-    return false;
-  }
-  if (UK_EU_PATTERN.test(normalized)) {
-    return true;
-  }
-  if (normalized.length === 7 && GENERIC_PATTERN.test(normalized)) {
-    return true;
-  }
-  return GENERIC_PATTERN.test(normalized);
+  return UK_STANDARD_PATTERN.test(normalized);
 }
 
 export function scorePlateConfidence(text, baseConfidence) {
   const normalized = normalizePlate(text);
   let confidenceBoost = 0;
-  if (UK_EU_PATTERN.test(normalized)) {
-    confidenceBoost += 10;
-  } else if (GENERIC_PATTERN.test(normalized)) {
-    confidenceBoost += 5;
+  if (UK_STANDARD_PATTERN.test(normalized)) {
+    confidenceBoost += 15;
   }
   const adjusted = Math.max(0, Math.min(100, Number(baseConfidence || 0) + confidenceBoost));
   return adjusted;
@@ -57,7 +39,7 @@ export function tryMatchPlate(text, baseConfidence) {
     raw: text,
     normalized,
     formatted: formatPlate(normalized),
-    isHighConfidence: UK_EU_PATTERN.test(normalized),
+    isHighConfidence: UK_STANDARD_PATTERN.test(normalized),
     baseConfidence: Number(baseConfidence || 0),
   };
 }

--- a/scripts/recognition-engine.js
+++ b/scripts/recognition-engine.js
@@ -1,0 +1,64 @@
+import { analyzeWithFastAlpr, ensureFastAlpr } from './fastalpr-engine.js';
+import { ensureWorker, recognize } from './ocr.js';
+import { wordsToDetections } from './detections.js';
+
+const engineState = {
+  fallbackActive: false,
+};
+
+function notify(reportStatus, state) {
+  if (typeof reportStatus === 'function' && state) {
+    try {
+      reportStatus(state);
+    } catch (error) {
+      console.error('Status listener failed', error);
+    }
+  }
+}
+
+export async function ensureRecognitionEngine(reportStatus) {
+  if (!engineState.fallbackActive) {
+    try {
+      await ensureFastAlpr(reportStatus);
+      return 'fastalpr';
+    } catch (error) {
+      console.warn('FastALPR initialisation failed. Falling back to OCR.', error);
+      engineState.fallbackActive = true;
+      notify(reportStatus, {
+        status: 'loading',
+        message: 'FastALPR unavailable. Falling back to OCR.',
+        progress: 0.2,
+      });
+    }
+  }
+
+  await ensureWorker(reportStatus);
+  return 'ocr';
+}
+
+async function runOcrFallback(canvas, source, reportStatus) {
+  const result = await recognize(canvas, reportStatus);
+  const words = Array.isArray(result?.data?.words) ? result.data.words : [];
+  return wordsToDetections(words, canvas.width, canvas.height, source);
+}
+
+export async function analyzeFrame(canvas, source, reportStatus) {
+  if (!engineState.fallbackActive) {
+    try {
+      return await analyzeWithFastAlpr(canvas, source, reportStatus);
+    } catch (error) {
+      console.error('FastALPR inference failed. Switching to OCR fallback.', error);
+      engineState.fallbackActive = true;
+      notify(reportStatus, {
+        status: 'loading',
+        message: 'Switching to OCR fallback',
+        progress: 0.2,
+      });
+    }
+  }
+  return runOcrFallback(canvas, source, reportStatus);
+}
+
+export function resetRecognitionEngineForTests() {
+  engineState.fallbackActive = false;
+}

--- a/scripts/tesseract-loader.js
+++ b/scripts/tesseract-loader.js
@@ -1,16 +1,4 @@
-function getBaseUrl() {
-  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.BASE_URL) {
-    return import.meta.env.BASE_URL;
-  }
-  return '/';
-}
-
-function withBase(path) {
-  const base = getBaseUrl();
-  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
-  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
-  return `${normalizedBase}${normalizedPath}`;
-}
+import { withBase } from './assetPaths.js';
 
 const LOCAL_ASSET_BASE = withBase('vendor/tesseract/');
 

--- a/tests/detections.test.js
+++ b/tests/detections.test.js
@@ -39,7 +39,7 @@ describe('wordsToDetections', () => {
     const detection = detections[0];
     expect(detection.plate).toBe('AB12CDE');
     expect(detection.formattedPlate).toBe('AB12 CDE');
-    expect(detection.confidence).toBe(77);
+    expect(detection.confidence).toBe(82);
     expect(detection.source).toBe('camera');
     expect(detection.capturedAt).toBe(new Date('2024-01-02T03:04:05Z').getTime());
     expect(detection.bbox).toEqual({
@@ -74,11 +74,9 @@ describe('wordsToDetections', () => {
       'upload',
     );
 
-    expect(results).toHaveLength(2);
+    expect(results).toHaveLength(1);
     expect(results[0].plate).toBe('AB12CDE');
-    expect(results[0].confidence).toBe(90);
-    expect(results[1].plate).toBe('XYZ1234');
-    expect(results[1].confidence).toBe(75);
+    expect(results[0].confidence).toBe(95);
     expect(results[0].bbox.left).toBeCloseTo(0.05);
   });
 });

--- a/tests/plateMatcher.test.js
+++ b/tests/plateMatcher.test.js
@@ -28,16 +28,16 @@ describe('isLikelyPlate', () => {
     expect(isLikelyPlate('A12')).toBe(false);
   });
 
-  it('accepts reasonable alphanumeric patterns', () => {
+  it('accepts modern UK plate patterns and rejects others', () => {
     expect(isLikelyPlate('AB12CDE')).toBe(true);
-    expect(isLikelyPlate('1234ABC')).toBe(true);
+    expect(isLikelyPlate('1234ABC')).toBe(false);
   });
 });
 
 describe('scorePlateConfidence', () => {
   it('boosts confidence for plates that match known patterns', () => {
-    expect(scorePlateConfidence('AB12CDE', 70)).toBe(80);
-    expect(scorePlateConfidence('ZZZ1234', 40)).toBe(45);
+    expect(scorePlateConfidence('AB12CDE', 70)).toBe(85);
+    expect(scorePlateConfidence('ZZZ1234', 40)).toBe(40);
   });
 
   it('never returns a value above 100 or below 0', () => {

--- a/tools/prepare-alpr-assets.js
+++ b/tools/prepare-alpr-assets.js
@@ -1,0 +1,122 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const ROOT_DIR = process.cwd();
+const ORT_SOURCE_DIR = path.join(ROOT_DIR, 'node_modules', 'onnxruntime-web', 'dist');
+const ORT_TARGET_DIR = path.join(ROOT_DIR, 'public', 'vendor', 'onnxruntime');
+const FASTALPR_TARGET_DIR = path.join(ROOT_DIR, 'public', 'vendor', 'fastalpr');
+
+const ORT_FILES = [
+  'ort.all.min.js',
+  'ort-wasm-simd-threaded.wasm',
+  'ort-wasm-simd-threaded.jsep.wasm',
+  'ort-wasm-simd-threaded.mjs',
+  'ort-wasm-simd-threaded.jsep.mjs',
+];
+
+const FASTALPR_MODELS = [
+  {
+    filename: 'yolo-v9-t-384-license-plates-end2end.onnx',
+    envVar: 'FASTALPR_DETECTOR_URL',
+    description: 'FastALPR detector ONNX model',
+  },
+  {
+    filename: 'global_mobile_vit_v2_ocr.onnx',
+    envVar: 'FASTALPR_OCR_URL',
+    description: 'FastALPR OCR ONNX model',
+  },
+];
+
+function getBaseUrl() {
+  const base = process.env.FASTALPR_ASSET_BASE_URL;
+  if (typeof base !== 'string' || !base.trim()) {
+    return null;
+  }
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+async function ensureDirectory(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function copyFile(source, target) {
+  await fs.copyFile(source, target);
+  console.log(`Copied ${path.relative(ROOT_DIR, target)}`);
+}
+
+async function copyOnnxRuntimeAssets() {
+  await ensureDirectory(ORT_TARGET_DIR);
+  await Promise.all(
+    ORT_FILES.map(async (file) => {
+      const source = path.join(ORT_SOURCE_DIR, file);
+      const target = path.join(ORT_TARGET_DIR, file);
+      await copyFile(source, target);
+    }),
+  );
+}
+
+async function downloadFile(url, destination) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await fs.writeFile(destination, buffer);
+  console.log(`Downloaded ${path.relative(ROOT_DIR, destination)} from ${url}`);
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+function resolveModelUrl({ filename, envVar }) {
+  const explicitUrl = process.env[envVar];
+  if (explicitUrl && explicitUrl.trim()) {
+    return explicitUrl.trim();
+  }
+  const baseUrl = getBaseUrl();
+  if (baseUrl) {
+    return `${baseUrl}${filename}`;
+  }
+  return null;
+}
+
+async function prepareFastAlprModels() {
+  await ensureDirectory(FASTALPR_TARGET_DIR);
+
+  const baseUrl = getBaseUrl();
+  if (baseUrl) {
+    console.log(`Using FASTALPR_ASSET_BASE_URL=${baseUrl} for model downloads.`);
+  }
+
+  for (const model of FASTALPR_MODELS) {
+    const target = path.join(FASTALPR_TARGET_DIR, model.filename);
+    if (await fileExists(target)) {
+      console.log(`Found existing ${path.relative(ROOT_DIR, target)}, skipping download.`);
+      continue;
+    }
+    const url = resolveModelUrl(model);
+    if (!url) {
+      console.warn(
+        `Missing ${model.description}. Set ${model.envVar} or FASTALPR_ASSET_BASE_URL to download it automatically.`,
+      );
+      continue;
+    }
+    await downloadFile(url, target);
+  }
+}
+
+async function main() {
+  await copyOnnxRuntimeAssets();
+  await prepareFastAlprModels();
+}
+
+main().catch((error) => {
+  console.error('Failed to prepare ALPR assets:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- remove the committed FastALPR/ONNX Runtime binaries and document how to provide them locally or via CDN
- make the FastALPR engine and ONNX Runtime loader try configurable URL lists with CDN fallbacks instead of hardcoded vendor paths
- extend the prepare script and README so installers can download the ONNX models via FASTALPR_* environment variables

## Testing
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68cd7f57e4c88322a5a565b94d62e85f