### PR TITLE
Fix asset base path resolution

### DIFF
--- a/scripts/assetPaths.js
+++ b/scripts/assetPaths.js
@@ -1,7 +1,127 @@
-function getBaseUrl() {
-  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.BASE_URL) {
-    return import.meta.env.BASE_URL;
+const SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+function ensureTrailingSlash(value) {
+  if (!value) {
+    return '/';
   }
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function normalizePathname(pathname) {
+  if (!pathname) {
+    return '/';
+  }
+
+  let result = pathname;
+  if (!result.startsWith('/')) {
+    result = `/${result}`;
+  }
+
+  if (result === '/') {
+    return '/';
+  }
+
+  if (result.endsWith('/')) {
+    return result;
+  }
+
+  const segments = result.split('/');
+  const lastSegment = segments.pop() || '';
+  const looksLikeFile = lastSegment.includes('.');
+
+  if (!looksLikeFile) {
+    segments.push(lastSegment);
+    return ensureTrailingSlash(segments.join('/'));
+  }
+
+  const directory = segments.join('/');
+  if (!directory || directory === '.') {
+    return '/';
+  }
+
+  return ensureTrailingSlash(directory.startsWith('/') ? directory : `/${directory}`);
+}
+
+function normalizeCandidate(candidate) {
+  if (!candidate || typeof candidate !== 'string') {
+    return '';
+  }
+
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (SCHEME_PATTERN.test(trimmed) || trimmed.startsWith('//')) {
+    try {
+      const base = trimmed.startsWith('//')
+        ? `${globalThis.location?.protocol || 'https:'}${trimmed}`
+        : trimmed;
+      const parsed = new URL(base);
+      const normalizedPath = normalizePathname(parsed.pathname);
+      if (parsed.origin && parsed.origin !== 'null') {
+        return `${parsed.origin}${normalizedPath}`;
+      }
+      return normalizedPath;
+    } catch (error) {
+      return '';
+    }
+  }
+
+  return normalizePathname(trimmed);
+}
+
+function getBaseUrl() {
+  let envBase = undefined;
+  if (typeof import.meta !== 'undefined' && import.meta.env && typeof import.meta.env.BASE_URL === 'string') {
+    envBase = import.meta.env.BASE_URL;
+    if (envBase && envBase !== '/') {
+      return envBase;
+    }
+  }
+
+  const candidates = [];
+
+  if (typeof document !== 'undefined') {
+    const baseElement = typeof document.querySelector === 'function' ? document.querySelector('base[href]') : null;
+    if (baseElement && typeof baseElement.href === 'string') {
+      candidates.push(baseElement.href);
+    }
+    if (typeof document.baseURI === 'string') {
+      candidates.push(document.baseURI);
+    }
+  }
+
+  const loc = typeof globalThis !== 'undefined' ? globalThis.location : undefined;
+  if (loc) {
+    if (typeof loc.href === 'string') {
+      candidates.push(loc.href);
+    }
+    if (typeof loc.pathname === 'string') {
+      candidates.push(loc.pathname);
+    }
+  }
+
+  if (typeof import.meta !== 'undefined' && typeof import.meta.url === 'string') {
+    try {
+      const parentUrl = new URL('../', import.meta.url);
+      candidates.push(parentUrl.href);
+    } catch (error) {
+      candidates.push(import.meta.url);
+    }
+  }
+
+  for (const candidate of candidates) {
+    const normalized = normalizeCandidate(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  if (envBase) {
+    return envBase;
+  }
+
   return '/';
 }
 

--- a/tests/assetPaths.test.js
+++ b/tests/assetPaths.test.js
@@ -1,0 +1,39 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const ASSET_MODULE_PATH = '../scripts/assetPaths.js';
+
+describe('assetPaths base resolution', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    document.head.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    document.head.innerHTML = '';
+  });
+
+  it('uses import.meta.env.BASE_URL when provided', async () => {
+    vi.stubEnv('BASE_URL', '/custom/');
+    const { withBase } = await import(ASSET_MODULE_PATH);
+    expect(withBase('vendor/model.onnx')).toBe('/custom/vendor/model.onnx');
+  });
+
+  it('normalizes document.baseURI that points to a file', async () => {
+    vi.stubEnv('BASE_URL', '');
+    vi.spyOn(document, 'baseURI', 'get').mockReturnValue('https://example.com/plate-scanner/index.html');
+    const { withBase } = await import(ASSET_MODULE_PATH);
+    expect(withBase('vendor/model.onnx')).toBe('https://example.com/plate-scanner/vendor/model.onnx');
+  });
+
+  it('appends a trailing slash when document.baseURI lacks one', async () => {
+    vi.stubEnv('BASE_URL', '');
+    vi.spyOn(document, 'baseURI', 'get').mockReturnValue('https://example.com/plate-scanner');
+    const { withBase } = await import(ASSET_MODULE_PATH);
+    expect(withBase('vendor/model.onnx')).toBe('https://example.com/plate-scanner/vendor/model.onnx');
+  });
+});


### PR DESCRIPTION
## Summary
- compute asset base URLs from `<base>`, `document.baseURI`, or `location` when `import.meta.env.BASE_URL` is not set or just `/`
- add normalization helpers to handle trailing slashes and directory detection for absolute and relative URLs
- add unit tests covering `withBase` behaviour for env, document, and trailing-slash scenarios

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cdc085f67c8322841866da158747d6