### PR TITLE
Improve FastALPR asset fallback handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,12 +45,15 @@ ENV/
 # Generated OCR assets (copied from node_modules during install)
 public/vendor/tesseract/*
 !public/vendor/tesseract/README.md
+!public/vendor/tesseract/manifest.json
 
 # Generated FastALPR models (downloaded separately)
 public/vendor/fastalpr/*
 !public/vendor/fastalpr/README.md
 !public/vendor/fastalpr/*.yaml
+!public/vendor/fastalpr/manifest.json
 
 # ONNX Runtime Web binaries (copied from node_modules during install)
 public/vendor/onnxruntime/*
 !public/vendor/onnxruntime/README.md
+!public/vendor/onnxruntime/manifest.json

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ app:
    bundled paths if available. When no local ONNX Runtime assets are present,
    the app automatically falls back to the jsDelivr or unpkg CDNs.
 
+The loader reads `public/vendor/fastalpr/manifest.json` and
+`public/vendor/onnxruntime/manifest.json` to decide whether bundled assets are
+available. Running `npm run prepare:alpr` refreshes those manifests with the
+current file metadata; if you publish models elsewhere you can edit the
+manifests or set `window.fastAlprAssetConfig` to point at your CDN locations.
+
 On iOS devices you must access the site over HTTPS (GitHub Pages does this automatically). When testing locally with a phone,
 use a tool that provides HTTPS tunnelling (for example, `ngrok`) or host the static files from a service that offers HTTPS.
 

--- a/public/vendor/fastalpr/manifest.json
+++ b/public/vendor/fastalpr/manifest.json
@@ -1,0 +1,15 @@
+{
+  "generatedAt": null,
+  "modelsAvailable": false,
+  "models": [],
+  "modelBaseUrls": [],
+  "detectorModelUrls": [],
+  "ocrModelUrls": [],
+  "ocrConfigUrls": [
+    "vendor/fastalpr/global_mobile_vit_v2_ocr_config.yaml"
+  ],
+  "configAvailable": true,
+  "config": {
+    "path": "vendor/fastalpr/global_mobile_vit_v2_ocr_config.yaml"
+  }
+}

--- a/public/vendor/onnxruntime/manifest.json
+++ b/public/vendor/onnxruntime/manifest.json
@@ -1,0 +1,8 @@
+{
+  "generatedAt": null,
+  "bundled": false,
+  "version": null,
+  "files": [],
+  "sources": [],
+  "baseUrls": []
+}


### PR DESCRIPTION
## Summary
- add manifest awareness to the FastALPR loader so CDN fallbacks are used when bundled assets are absent
- emit manifest metadata when copying ONNX Runtime binaries and FastALPR models, including default manifest files in the repo
- document the manifests and update the README with guidance on how they are refreshed

## Testing
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68ce641feaf8832284ca723bd7fec40f